### PR TITLE
add getFast method to exported methods

### DIFF
--- a/test/psl.getFast.spec.js
+++ b/test/psl.getFast.spec.js
@@ -1,0 +1,44 @@
+/*eslint no-var:0, prefer-arrow-callback: 0 */
+'use strict';
+
+
+var Assert = require('assert');
+var Psl = require('../');
+
+var Data = [
+  {
+    value: 'google.co.uk',
+    expected: 'google.co.uk'
+  },
+  {
+    value: 'search.google.com',
+    expected: 'google.com'
+  },
+  {
+    value: 'one.playground.xyz',
+    expected: 'playground.xyz'
+  }
+];
+
+describe('psl.getFast()', function () {
+
+  Psl.precomputeFastRules(Data.map(function (item) {
+
+    return item.expected;
+  }));
+
+  Data.forEach(function (item) {
+
+    it('psl.getFast(' + item.value + ') should return ' + item.expected, function () {
+
+      Assert.equal(Psl.getFast(item.value), item.expected);
+    });
+
+  });
+
+  it('psl.getFast(example.gov.uk) should return null for non-precomputed domain', function () {
+
+    Assert.equal(Psl.getFast('example.gov.uk'), null);
+  });
+});
+


### PR DESCRIPTION
I've implemented an optional faster way of parsing domains by reducing the list of rules based on a precomputed set of domains. This was useful for an internal use-case so I thought I'd see if you thought was worth including upstream.

If so, I'm happy to add some docs explaining the usage and any API changes you recommend.