### PR TITLE
use maps for rule search, add benchmark

### DIFF
--- a/benchmark/suite.js
+++ b/benchmark/suite.js
@@ -1,0 +1,24 @@
+const Benchmark = require('benchmark');
+const psl = require('../')
+
+const suite = new Benchmark.Suite();
+suite.add('psl#isValid', {
+  fn: () => {
+    psl.isValid('google.com');
+  }
+});
+suite.add('psl#parse', {
+  fn: () => {
+    psl.parse('google.com');
+  }
+});
+suite.add('psl#parse invalid domain', {
+  fn: () => {
+    psl.parse('google.comp');
+  }
+});
+    
+suite.on('cycle', (event) => {
+  console.log(String(event.target));
+});
+suite.run();

--- a/index.js
+++ b/index.js
@@ -4,7 +4,6 @@
 
 var Punycode = require('punycode');
 
-
 var internals = {};
 
 
@@ -12,16 +11,21 @@ var internals = {};
 // Read rules from file.
 //
 internals.rules = require('./data/rules.json').map(function (rule) {
-
+  const suffix = rule.replace(/^(\*\.|\!)/, '');
   return {
     rule: rule,
-    suffix: rule.replace(/^(\*\.|\!)/, ''),
-    punySuffix: -1,
+    suffix,
+    punySuffix: Punycode.toASCII(suffix),
     wildcard: rule.charAt(0) === '*',
     exception: rule.charAt(0) === '!'
   };
 });
 
+internals.rulesBySuffix = new Map();
+for (var rule of internals.rules) {
+  var existingRules = internals.rulesBySuffix.get(rule.punySuffix);
+  internals.rulesBySuffix.set(rule.punySuffix, existingRules ? existingRules.concat(rule) : [rule]);
+}
 
 //
 // Check if given string ends with `suffix`.
@@ -31,6 +35,12 @@ internals.endsWith = function (str, suffix) {
   return str.indexOf(suffix, str.length - suffix.length) !== -1;
 };
 
+//
+// ASCII string reverse function
+//
+internals.reverse = function (str) {
+  return str.split("").reverse().join("")
+}
 
 //
 // Find rule for a given domain.
@@ -38,11 +48,19 @@ internals.endsWith = function (str, suffix) {
 internals.findRule = function (domain) {
 
   var punyDomain = Punycode.toASCII(domain);
-  return internals.rules.reduce(function (memo, rule) {
-
-    if (rule.punySuffix === -1) {
-      rule.punySuffix = Punycode.toASCII(rule.suffix);
+  var punyDomainChunks = punyDomain.split('.');
+  var matchingRules;
+  for (var i = 0; i < punyDomainChunks.length; i++) {
+    var suffix = punyDomainChunks.slice(i).join('.');
+    var matchingRules = internals.rulesBySuffix.get(suffix);
+    if (matchingRules) {
+      break;
     }
+  }
+  if (!matchingRules) {
+    return null;
+  }
+  return matchingRules.reduce(function (memo, rule) {
     if (!internals.endsWith(punyDomain, '.' + rule.punySuffix) && punyDomain !== rule.punySuffix) {
       return memo;
     }
@@ -208,6 +226,7 @@ exports.parse = function (input) {
     if (domainParts.length) {
       parsed.subdomain = domainParts.pop();
     }
+    
     return handlePunycode();
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.9.0",
       "license": "MIT",
       "devDependencies": {
+        "benchmark": "^2.1.4",
         "browserify": "^17.0.0",
         "browserslist-browserstack": "^3.1.1",
         "browserstack-local": "^1.5.1",
@@ -345,6 +346,16 @@
       "dev": true,
       "dependencies": {
         "tweetnacl": "^0.14.3"
+      }
+    },
+    "node_modules/benchmark": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-2.1.4.tgz",
+      "integrity": "sha512-l9MlfN4M1K/H2fbhfMy3B7vJd6AGKJVQn2h6Sg/Yx+KckoUA7ewS5Vv6TjSq18ooE1kS9hhAlQRH3AkXIh/aOQ==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.4",
+        "platform": "^1.3.3"
       }
     },
     "node_modules/binary-extensions": {
@@ -3424,6 +3435,12 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
+      "dev": true
+    },
     "node_modules/porch": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/porch/-/porch-2.0.0.tgz",
@@ -5046,6 +5063,16 @@
       "dev": true,
       "requires": {
         "tweetnacl": "^0.14.3"
+      }
+    },
+    "benchmark": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-2.1.4.tgz",
+      "integrity": "sha512-l9MlfN4M1K/H2fbhfMy3B7vJd6AGKJVQn2h6Sg/Yx+KckoUA7ewS5Vv6TjSq18ooE1kS9hhAlQRH3AkXIh/aOQ==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.4",
+        "platform": "^1.3.3"
       }
     },
     "binary-extensions": {
@@ -7466,6 +7493,12 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
       "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+      "dev": true
+    },
+    "platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
       "dev": true
     },
     "porch": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "author": "Lupo Montero <lupomontero@gmail.com> (https://lupomontero.com/)",
   "license": "MIT",
   "devDependencies": {
+    "benchmark": "^2.1.4",
     "browserify": "^17.0.0",
     "browserslist-browserstack": "^3.1.1",
     "browserstack-local": "^1.5.1",


### PR DESCRIPTION
Problem:

There are 9000 rules and to check domain validity we need to iterate over them. It is hard to use map because we need to search by substring, performance `O(domainsCount * ruleCount)`

Solution:

1. Added benchmark.js checks to get observability
2. During module load we process punySuffix for every domain. It is a very cheap operation `O(ruleCount)`
3. During module load we create a map `suffix => [rule1, rule2, ..]`, which usually has 1 element  `O(ruleCount)`
4. During search we split the domain by dots and search in the map. `O(1)`

E.g. for mysubdomain.google.co.uk:
1. search rule map for mysubdomain.google.co.uk => nothing
2. search rule map for google.co.uk => nothing
3. searching rule map for .co.uk => found
4. returting rule for .co.uk

Fixes #301