### PR TITLE
refactor(benchmark): Adds sanitiseVersion function

### DIFF
--- a/benchmark/suite.js
+++ b/benchmark/suite.js
@@ -44,7 +44,7 @@ const runSuites = (suites) => {
   return recurse(suites, [])
 };
 
-const printResults = (results, compareToVersion) => {
+const printResults = (results, versionToCompare) => {
   const parsedResults = results.map(result => ({
     version: result.version,
     name: result.name,
@@ -75,7 +75,7 @@ const printResults = (results, compareToVersion) => {
   const resultsByFuncSummary = Object.keys(resultsByFunc).reduce(
     (memo, name) => {
       const sourceOpsXSec = parseInt(resultsByFunc[name].source, 10);
-      const compareToOpsXSec = parseInt(resultsByFunc[name][compareToVersion], 10);
+      const compareToOpsXSec = parseInt(resultsByFunc[name][versionToCompare], 10);
       const diff = (
         sourceOpsXSec > compareToOpsXSec
           ? `${(sourceOpsXSec / compareToOpsXSec).toFixed(2)}x up`
@@ -125,13 +125,13 @@ const sanitiseVersion = (version = 'latest') => {
 };
 
 const main = async () => {
-  const compareToVersion = sanitiseVersion(process.argv[2]);
+  const versionToCompare = sanitiseVersion(process.argv[2]);
   const results = await runSuites([
     { module: psl, version: 'source' },
-    { module: await fetchModule(compareToVersion), version: compareToVersion },
+    { module: await fetchModule(versionToCompare), version: versionToCompare },
   ]);
 
-  printResults(results, compareToVersion);
+  printResults(results, versionToCompare);
 };
 
 main().catch((error) => {

--- a/benchmark/suite.js
+++ b/benchmark/suite.js
@@ -109,7 +109,23 @@ const fetchModule = async (version) => {
   return mod.namespace;
 };
 
-const main = async (compareToVersion = 'latest') => {
+const sanitiseVersion = (version = 'latest') => {
+  const semverRegExp = new RegExp([
+    '^v(0|[1-9]\\d*)',
+    '\\.(0|[1-9]\\d*)',
+    '\\.(0|[1-9]\\d*|x)',
+    '(?:[-]?[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?$'
+   ].join(''));
+
+  if (version !== 'latest' && !semverRegExp.test(version)) {
+    throw new Error(`Unknown version argument: ${version}`);
+  }
+
+  return version;
+};
+
+const main = async () => {
+  const compareToVersion = sanitiseVersion(process.argv[2]);
   const results = await runSuites([
     { module: psl, version: 'source' },
     { module: await fetchModule(compareToVersion), version: compareToVersion },
@@ -118,7 +134,7 @@ const main = async (compareToVersion = 'latest') => {
   printResults(results, compareToVersion);
 };
 
-main(process.argv[2]).catch((error) => {
+main().catch((error) => {
   console.error(error);
   process.exit(1);
 });


### PR DESCRIPTION
This PR adds a minimal sanitization for passing a `version` command line argument to the benchmark suite.

As it is now users get a random error back (`SyntaxError: Unexpected identifier 'find'`) when passing a unexpected/malformed version argument.

With this change this added function throws an error when it doesn't receive the [RegExp we're expecting](https://regex101.com/r/O6Nv85/1) as an argument, including a little bit more information.

The second commit only changes a variable's name; feel free to trim it. :blush: 

This PR also replaces #337 since I had included commits that were not supposed to be included.