### PR TITLE
feat(rules):allow addings custom rules

### DIFF
--- a/test/psl.spec.js
+++ b/test/psl.spec.js
@@ -6,5 +6,6 @@ describe('psl', () => {
     assert.equal(typeof psl.parse, 'function');
     assert.equal(typeof psl.get, 'function');
     assert.equal(typeof psl.isValid, 'function');
+    assert.equal(typeof psl.addRule, 'function');
   });
 });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -55,3 +55,8 @@ export function isValid(domain: string): boolean;
  * An array of TLDs used to parse domains.
  */
 export const rules: string[];
+
+/**
+ * Adds a rule to the collection.
+ */
+export function addRule(rule: string, replace?: boolean): boolean;


### PR DESCRIPTION
In a server environment, dependencies are generally not updated frequently, so the latest rules cannot be automatically updated. By using `addRule`, developers can fetch and add rules to `rulesByPunySuffix` map.